### PR TITLE
Sync about intro YOE to 13 years, drop StackEdit ref

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -3,13 +3,14 @@ title: "About Me"
 ---
 
 <!-- editors note:
-  This about me lives here canonically, but is then synced to several places.
-  1. https://stackedit.io/app# (for PDF resume generation)
-  2. https://github.com/coilysiren/coilysiren/blob/main/README.md
-  3. https://www.linkedin.com/in/coilysiren/
+  Canonical source is ~/projects/coilyco-vault/coilyco/Self/Resume.md.
+  This file (and the following downstream targets) are synced from it:
+  1. https://github.com/coilysiren/coilysiren/blob/main/README.md
+  2. https://www.linkedin.com/in/coilysiren/ (manual paste via UI)
+  PDF resume is regenerated automatically via the `pdf` skill, not StackEdit.
 -->
 
-I'm **Kai Siren** (preferred name), AKA **Lynn Conway** (legal name). I’m a platform engineer with over 10 years of experience building high-impact systems that empower engineering teams.
+I'm **Kai Siren** (preferred name), AKA **Lynn Conway** (legal name). I’m a platform engineer with 13 years of experience building high-impact systems that empower engineering teams.
 
 I have recent experience working with LLM-based systems and AI-assisted workflows, focusing on integrating them into existing platforms in a reliable and observable way. This includes designing systems that help teams experiment with and adopt AI without compromising production quality.
 


### PR DESCRIPTION
## Summary

- Update intro paragraph from "over 10 years" to "13 years" to match the canonical `Resume.md` in the vault (Kai started in tech at 20, is now 33, so 13 YOE as of 2026-04).
- Drop the StackEdit reference from the editor's note. PDF resume regeneration now goes through the `pdf` skill directly, not StackEdit.

## Test plan

- [ ] Visual check of /about rendering locally (intro reads "13 years").
- [ ] Confirm no other places on the site claim "over 10 years."

🤖 Generated with [Claude Code](https://claude.com/claude-code)