### PR TITLE
refresh resume.pdf from current Resume.md

### DIFF
--- a/static/resume.pdf
+++ b/static/resume.pdf
@@ -190,7 +190,7 @@ endobj
 endobj
 28 0 obj
 <<
-/Author (Kai Siren) /CreationDate (D:20260417180433-07'00') /Creator (coilysiren) /Keywords () /ModDate (D:20260417180433-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (Kai Siren) /CreationDate (D:20260417191416-07'00') /Creator (coilysiren) /Keywords () /ModDate (D:20260417191416-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (Resume) /Title (Kai Siren \204 Resume) /Trapped /False
 >>
 endobj
@@ -250,7 +250,7 @@ xref
 trailer
 <<
 /ID 
-[<c59f2968695e0afc6210cad97f745a25><c59f2968695e0afc6210cad97f745a25>]
+[<4985f243bcd12ae88f5f0d0d5755b7e9><4985f243bcd12ae88f5f0d0d5755b7e9>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 28 0 R


### PR DESCRIPTION
## Summary
- Regenerate `static/resume.pdf` from the canonical `coilyco-vault/.../Resume.md` via `scripts/build-resume.py`
- No source edits — just bringing the rendered artifact back in sync

## Test plan
- [ ] Download the PDF from the PR checks / preview and confirm it opens and reflects current Resume.md content