### PR TITLE
pin Netlify Node to 22 (fixes stale-cache build break)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
 
 [build.environment]
   NETLIFY_USE_PNPM = "true"
+  NODE_VERSION = "22"
 
 [[redirects]]
   from = "/about"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "build": "gatsby clean && gatsby build",
+    "build": "gatsby clean && gatsby build --verbose",
     "dev": "gatsby clean && gatsby develop",
     "serve": "gatsby serve --port 8000 --host 0.0.0.0",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "build": "gatsby clean && gatsby build --verbose",
+    "build": "gatsby clean && gatsby build",
     "dev": "gatsby clean && gatsby develop",
     "serve": "gatsby serve --port 8000 --host 0.0.0.0",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Pin `NODE_VERSION = "22"` in `netlify.toml` (defensive — Netlify default Node 18 is approaching EOL)
- The actual production breakage was a stale Netlify build cache restored by `gatsby-adapter-netlify` from before the pnpm/TS migration. A one-time clear-cache deploy on main is also required.

## Test plan
- [x] Branch deploy with cleared cache builds: https://fix-netlify-node-22--coilysiren-dot-me.netlify.app
- [ ] Merge then trigger clear-cache build on main; confirm production deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)